### PR TITLE
ignore *.cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+*.cache


### PR DESCRIPTION
Makes using the repo as a submodule more pleasant.
